### PR TITLE
Mistake in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ P(MySuperclass, function(proto, super, class, superclass) {
 
 // for shorthand, you can pass an object in lieu of the function argument,
 // but you lose the niceness of super and private methods.
-Limbo({ init: function(a) { this.thing = a } });
+P({ init: function(a) { this.thing = a } });
 
 MyClass = P(function(p) { p.init = function() { console.log("init!") }; });
 // instantiate objects by calling the class


### PR DESCRIPTION
I haven't tested this, but I'm pretty sure you meant for the instance of `Limbo` to be replaced with `P` in the Readme.
