### PR TITLE
Use ./node_modules in Makefile, so can just npm install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SRC = $(SRC_DIR)/p.js
 all: minify commonjs amd report
 
 # -*- minification -*- #
-UGLIFYJS ?= uglifyjs
+UGLIFYJS ?= ./node_modules/.bin/uglifyjs
 UGLIFY_OPTS += --lift-vars --unsafe
 UGLY = $(BUILD_DIR)/p.min.js
 
@@ -38,8 +38,8 @@ report: $(UGLY)
 	wc -c $(UGLY)
 
 # -*- testing -*- #
-MOCHA ?= mocha
-JSHINT ?= jshint
+MOCHA ?= ./node_modules/.bin/mocha
+JSHINT ?= ./node_modules/.bin/jshint
 TESTS = ./test/*.test.js
 .PHONY: test
 test: jshint $(COMMONJS)

--- a/README.md
+++ b/README.md
@@ -136,7 +136,18 @@ MyClass().foo() // => 3
 
 ## what is all this Makefile stuff about
 
-It's super useful!  Here are the things you can build:
+It's super useful! In addition to `make`, Pjs uses some build tools written on
+[Node][]. With the [Node Package Manager][npm] that comes with recent versions
+of it, just run
+
+    npm install
+
+from the root directory of the repo and `make` will start working.
+
+[Node]: http://nodejs.org/#download
+[npm]: http://npmjs.org
+
+Here are the things you can build:
 
 - `make minify`
     generates `build/p.min.js`
@@ -150,6 +161,5 @@ It's super useful!  Here are the things you can build:
 - `make test`
     runs the test suite using the commonjs version.  Requires `mocha`.
 
-(*) uglifyjs is required for some of these.
-
-(**) I tested these tasks with GNU make.  If someone could verify this all works with BSD make (like on a Mac) that'd be awesome.
+(I tested these tasks with GNU make.  If someone could verify this all works
+with BSD make (like on a Mac) that'd be awesome.)


### PR DESCRIPTION
Use `./node_modules/.bin/*` in Makefile, so potential contributors who clone the repo can [just run `npm install`](http://blog.nodejs.org/2011/03/23/npm-1-0-global-vs-local-installation/) and be ready to roll

See also mathquill/mathquill#116
