### PR TITLE
fix `myObj.constructor(a, b, c)` with private allocator noop

### DIFF
--- a/src/p.js
+++ b/src/p.js
@@ -37,19 +37,26 @@ var P = (function(prototype, ownProperty, undefined) {
     //  TODO: the Chrome inspector shows all created objects as `C` rather than `Object`.
     //        Setting the .name property seems to have no effect.  Is there a way to override
     //        this behavior?
-    function C(args) {
-      var self = this;
-      if (!(self instanceof C)) return new C(arguments);
-      if (args && isFunction(self.init)) self.init.apply(self, args);
+    function C() {
+      var self = new alloc;
+      if (isFunction(self.init)) self.init.apply(self, arguments);
+      return self;
+    }
+    function alloc(){}
+
+    var _super = _superclass[prototype],
+        _superalloc = _superclass;
+    if (_super) {
+      _superalloc = function(){};
+      _superalloc[prototype] = _super;
     }
 
     // set up the prototype of the new class
     // note that this resolves to `new Object`
     // if the superclass isn't given
-    var proto = C[prototype] = new _superclass();
+    var proto = alloc[prototype] = C[prototype] = new _superalloc();
 
     // other variables, as a minifier optimization
-    var _super = _superclass[prototype];
     var extensions;
 
     // set the constructor property on the prototype, for convenience

--- a/test/p.test.js
+++ b/test/p.test.js
@@ -20,6 +20,15 @@ describe('P', function() {
       assert.ok(new MyClass instanceof MyClass);
       assert.ok(MyClass() instanceof MyClass);
     });
+
+    it('respects `.constructor`', function() {
+      var o = MyClass();
+      assert.ok(o.constructor === MyClass);
+
+      var o2 = o.constructor();
+      assert.ok(o2 instanceof MyClass);
+      assert.ok(o2.foo === 1);
+    });
   });
 
   describe('init', function() {
@@ -38,15 +47,13 @@ describe('P', function() {
       assert.equal(2, MyClass.apply(null, [1, 2, 3]).initArgs[1]);
     });
 
-    it('is not called when the new keyword is given', function() {
-      assert.ok(!(new MyClass).initCalled);
+    it('is called when the class is called with `new`', function() {
+      assert.ok((new MyClass).initCalled);
+      assert.equal(3, (new MyClass(1,2,3)).initArgs[2]);
     });
 
-    it('is called when an argument is passed with `new`', function() {
-      var obj = new MyClass([1, 2]);
-      assert.ok(obj.initCalled);
-      assert.equal(1, obj.initArgs[0]);
-      assert.equal(2, obj.initArgs[1]);
+    it('is not called when the alloc property is called with `new`', function() {
+      assert.ok(!(new MyClass.alloc).initCalled);
     });
   });
 


### PR DESCRIPTION
by breaking `new MyClass([a, b, c])`, but making `new MyClass(a, b, c)` now do what you expect. Instead of re-using the same function that's called externally to instantiate the class for the actual prototype extension, have a separate `alloc` noop just for actual prototype extension, and have a similar `_superalloc` noop when subclassing.

add test case for `.constructor`, and change test cases for init to expect the new behavior of `new`.

differs from #10 in that instead of a public `.alloc` property on the resulting Pjs class, uses a private closured `alloc` noop and another private closured `_superalloc` noop when subclassing.

Note that this is behaviorally different when creating the prototype of a new Pjs class when subclassing a non-Pjs class: #10 will call `new` on the constructor of the non-Pjs class, whereas this will essentially `Object.create()` the `.prototype` of the constructor of the non-Pjs class.
