### PR TITLE
Updated Makefile for Uglify2, npm ignore, Mac OSX + perf notes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 
 npm-*.log
 /node_modules
+
+*.un~

--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,14 @@ all: minify commonjs amd report
 
 # -*- minification -*- #
 UGLIFYJS ?= ./node_modules/.bin/uglifyjs
-UGLIFY_OPTS += --lift-vars --unsafe
+UGLIFY_OPTS += -m -c hoist_vars=true,unsafe=true
 UGLY = $(BUILD_DIR)/p.min.js
 
 $(UGLY): $(SRC)
-	$(UGLIFYJS) $(UGLIFY_OPTS) $< > $@
+	$(UGLIFYJS) $(UGLIFY_OPTS) $< -o $@
 
 %.min.js: %.js
-	$(UGLIFYJS) $(UGLIFY_OPTS) $< > $@
+	$(UGLIFYJS) $(UGLIFY_OPTS) $< -o $@
 
 minify: $(UGLY)
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ tom.move()
 
 ## how is pjs different from X
 
-Most class systems for JS let you define classes by passing an object.  P.js lets you pass a function instead, which allows you to closure private methods and macros.  It's also 546 bytes minified (see `make report`).
+Most class systems for JS let you define classes by passing an object.  P.js lets you pass a function instead, which allows you to closure private methods and macros.  It's also 548 bytes minified (see `make report`).
 
 ### why doesn't pjs suck?
 
@@ -173,6 +173,3 @@ Here are the things you can build:
 
 - `make test`
     runs the test suite using the commonjs version.  Requires `mocha`.
-
-(I tested these tasks with GNU make.  If someone could verify this all works
-with BSD make (like on a Mac) that'd be awesome.)


### PR DESCRIPTION
Thanks for your work on this lib.. nice way to deal with JS prototypes. Here are a couple housekeeping edits I made for npm + uglify.
1. Vim undo files `*.un~` should now be ignored by npm.
2. I noticed that your uglify options were outdated since you're using the edge version in your pacakge.json. These new Makefile edits should update the uglify usage to v2.
3. Makefile is working fine on OSX (we're on GNU Make 3.81 now). Tests are passing, although I'm not sure if they were ran against the .min files.
4. For giggles, I created a jsperf test for P.js. Here: http://jsperf.com/oop-native-vs-pjs
