### PR TITLE
Fix idiomatic subclasses of Pjs classes #backcompatBreaking 

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ tom.move()
 
 ## how is pjs different from X
 
-Most class systems for JS let you define classes by passing an object.  P.js lets you pass a function instead, which allows you to closure private methods and macros.  It's also 548 bytes minified (see `make report`).
+Most class systems for JS let you define classes by passing an object.  P.js lets you pass a function instead, which allows you to closure private methods and macros.  It's also 560 bytes minified (see `make report`).
 
 ### why doesn't pjs suck?
 
@@ -112,8 +112,22 @@ MyClass(1, 2) // => init!, 1, 2
 var argsList = [1, 2];
 MyClass.apply(null, argsList) // init!, 1, 2
 
+// you can use it like an idiomatic class:
 // `new` is optional, not really recommended.
 new MyClass(1, 2) // => init!, 1, 2
+// non-pjs idiomatic subclass
+function Subclass(a) { MyClass.call(this, a, a); }
+new Subclass(3) // => init!, 3, 3
+new Subclass(3) instanceof MyClass // => true
+
+// `new` may be used to "force" instantiation when ambiguous,
+// for example in a factory method that creates new instances
+MyClass.prototype.clone = function(a, b) {
+  return new this.constructor(a, b);
+};
+// because without `new`, `this.constructor(a, b)` is equivalent to
+// `MyClass.call(this, a, b)` which as we saw in the previous example
+// mutates `this` rather than creating new instances
 
 // allocate uninitialized objects with .Bare
 // (much like Ruby's Class#allocate)

--- a/README.md
+++ b/README.md
@@ -105,8 +105,12 @@ P(MySuperclass, function(proto, super, class, superclass) {
 P({ init: function(a) { this.thing = a } });
 
 MyClass = P(function(p) { p.init = function(a, b) { console.log("init!", a, b) }; });
-// instantiate objects by calling the class
+// instantiate objects by calling the class as a function
 MyClass(1, 2) // => init!, 1, 2
+
+// to initialize with varargs, use `apply` like any other function.
+var argsList = [1, 2];
+MyClass.apply(null, argsList) // init!, 1, 2
 
 // `new` is optional, not really recommended.
 new MyClass(1, 2) // => init!, 1, 2
@@ -115,10 +119,6 @@ new MyClass(1, 2) // => init!, 1, 2
 // (much like Ruby's Class#allocate)
 new MyClass.Bare // nothing logged
 new MyClass.Bare instanceof MyClass // => true
-
-// to initialize with varargs, use `apply` like any other function.
-var argsList = [1, 2];
-MyClass.apply(null, argsList) // init!, 1, 2
 
 // you can use `.open` to reopen a class.  This has the same behavior
 // as the regular definitions.

--- a/src/p.js
+++ b/src/p.js
@@ -16,15 +16,15 @@ var P = (function(prototype, ownProperty, undefined) {
 
     // C is the class to be returned.
     //
-    // It delegates to instantiating an instance of `Bare`, so that it
-    // will always return a new instance regardless of the calling
-    // context.
+    // When called, creates and initializes an instance of C, unless
+    // `this` is already an instance of C, then just initializes `this`;
+    // either way, returns the instance of C that was initialized.
     //
     //  TODO: the Chrome inspector shows all created objects as `C`
     //        rather than `Object`.  Setting the .name property seems to
     //        have no effect.  Is there a way to override this behavior?
     function C() {
-      var self = new Bare;
+      var self = this instanceof C ? this : new Bare;
       if (isFunction(self.init)) self.init.apply(self, arguments);
       return self;
     }

--- a/test/p.test.js
+++ b/test/p.test.js
@@ -25,9 +25,13 @@ describe('P', function() {
       var o = MyClass();
       assert.ok(o.constructor === MyClass);
 
-      var o2 = o.constructor();
+      var o2 = new o.constructor();
       assert.ok(o2 instanceof MyClass);
       assert.ok(o2.foo === 1);
+
+      var o3 = o.constructor.call(null);
+      assert.ok(o3 instanceof MyClass);
+      assert.ok(o3.foo === 1);
     });
   });
 


### PR DESCRIPTION
Prior to this commit an idiomatic subclass of a Pjs class would fail to inherit the constructor, for example:

``` js
function Subclass(info, moreInfo) {
  // ...
  var arg1 = slightlyChange(info), arg2 = drasticallyChange(moreInfo);
  // ...
  Superclass.call(this, arg1, arg2);
}
```

would silently create and discard a new instance of `Superclass` and not mutate as `this` as intended.

Of course, if you're writing your idiomatic subclass of a Pjs class by hand, you can just do `this.init(arg1, arg2)` and you're golden.  However, in [CoffeeScript](http://coffeescript.org/#classes) and even [ECMAScript 6 (Harmony)](http://wiki.ecmascript.org/doku.php?id=strawman:minimal_classes#super), `super(arg1, arg2)` compiles to `Superclass.call(this, arg1, arg2)`, and if you don't define a `constructor`, there's an implicit `Superclass.apply(this, arguments)`, which it's pretty lame to break.

The fix is a one-liner:

``` diff
     function C() {
-      var self = new Bare;
+      var self = this instanceof C ? this : new Bare;
       if (isFunction(self.init)) self.init.apply(self, arguments);
       return self;
     }
```

The only back-compat break is jneen#9: `this.constructor(arg1, arg2)` will also mutate `this`, being fundamentally equivalent to `C.call(this, arg1, arg2)`. But it occured to me that this isn't a problem for idiomatic classes because to instantiate them you do `new this.constructor(arg1, arg2)`, which we can make work for Pjs classes too, and just say that in that ambiguous case you use `new` to "force" instantiation. Note that for varargs you just do `this.constructor.apply(null, argsList)` as ever. (Btw we totally forgot to suggest `this.constructor.call(null)` in jneen#9.)

I really think that given the tradeoff of being a well-behaved class system vs the edge case of a factory method, especially considering how easy it is to just use `new`, we should favor being well-behaved.

The minified size does increase a smidgen, but fret not, I saw some ways to reduce minified size that I'll open separate PRs for. (Avoiding the repeated `this` intro'd in this change does not in fact reduce minified size, I tried that.)
