### PR TITLE
Simplify and reduce minified size without reducing functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ tom.move()
 
 ## how is pjs different from X
 
-Most class systems for JS let you define classes by passing an object.  P.js lets you pass a function instead, which allows you to closure private methods and macros.  It's also 544 bytes minified (see `make report`).
+Most class systems for JS let you define classes by passing an object.  P.js lets you pass a function instead, which allows you to closure private methods and macros.  It's also 519 bytes minified (see `make report`).
 
 ### why doesn't pjs suck?
 

--- a/src/p.js
+++ b/src/p.js
@@ -1,6 +1,5 @@
 var P = (function(prototype, ownProperty, undefined) {
   // helper functions that also help minification
-  function isObject(o) { return typeof o === 'object'; }
   function isFunction(f) { return typeof f === 'function'; }
 
   // used to extend the prototypes of superclasses (which might not
@@ -53,7 +52,7 @@ var P = (function(prototype, ownProperty, undefined) {
       }
 
       // ...and extend it
-      if (isObject(def)) {
+      if (typeof def === 'object') {
         for (var key in def) {
           if (ownProperty.call(def, key)) {
             proto[key] = def[key];


### PR DESCRIPTION
It's pretty awesome, actually.

Well, I think it doesn't reduce functionality; we don't actually have tests for the "object literal shorthand", you know that? Though the code is pretty trivial, and I also tried it in the Node REPL (but seriously, it was trivial, of course it worked). I'm also about to submit another PR that removes the object literal shorthand altogether, so I didn't feel like writing tests I was about to submit a PR to delete.
